### PR TITLE
Individually append arguments to command

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,10 +79,6 @@
             <artifactId>jcabi-maven-slf4j</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
         </dependency>

--- a/src/main/java/com/jcabi/dynamodb/maven/plugin/Instances.java
+++ b/src/main/java/com/jcabi/dynamodb/maven/plugin/Instances.java
@@ -32,17 +32,18 @@ package com.jcabi.dynamodb.maven.plugin;
 import com.jcabi.aspects.Loggable;
 import com.jcabi.log.VerboseProcess;
 import com.jcabi.log.VerboseRunnable;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+
 import javax.validation.constraints.NotNull;
-import lombok.EqualsAndHashCode;
-import lombok.ToString;
 
 /**
  * Running instances of DynamoDB Local.
@@ -142,25 +143,20 @@ final class Instances {
      */
     private static Process process(final File dist, final int port,
         final File home, final List<String> args) throws IOException {
-        final List<String> baseCommand = Arrays.asList(
-            new File(home, "bin/java").getAbsolutePath(),
-            new StringBuilder("-Djava.library.path=")
-                .append(dist)
-                .append(System.getProperty("path.separator"))
-                .append(new File(dist, "DynamoDBLocal_lib"))
-                .toString()
-            ,
-            "-jar",
-            "DynamoDBLocal.jar",
-            "--port",
-            Integer.toString(port)
-        );
-        final List<String> commandWithArgs =
-            new ArrayList<String>(baseCommand.size() + args.size());
-        commandWithArgs.addAll(baseCommand);
-        commandWithArgs.addAll(args);
-        return new ProcessBuilder().command(commandWithArgs)
-            .directory(dist).redirectErrorStream(true).start();
+        final int baseCommandCount = 6;
+        final List<String> command = new ArrayList<String>(baseCommandCount + args.size());
+        command.add(new File(home, "bin/java").getAbsolutePath());
+        command.add(new StringBuilder("-Djava.library.path=")
+                        .append(dist)
+                        .append(System.getProperty("path.separator"))
+                        .append(new File(dist, "DynamoDBLocal_lib"))
+                        .toString());
+        command.add("-jar");
+        command.add("DynamoDBLocal.jar");
+        command.add("--port");
+        command.add(Integer.toString(port));
+        command.addAll(args);
+        return new ProcessBuilder().command(command).directory(dist).redirectErrorStream(true).start();
     }
 
     /**

--- a/src/main/java/com/jcabi/dynamodb/maven/plugin/Instances.java
+++ b/src/main/java/com/jcabi/dynamodb/maven/plugin/Instances.java
@@ -34,6 +34,7 @@ import com.jcabi.log.VerboseProcess;
 import com.jcabi.log.VerboseRunnable;
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
@@ -41,7 +42,6 @@ import java.util.concurrent.ConcurrentMap;
 import javax.validation.constraints.NotNull;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
-import org.apache.commons.lang3.StringUtils;
 
 /**
  * Running instances of DynamoDB Local.
@@ -141,21 +141,20 @@ final class Instances {
      */
     private static Process process(final File dist, final int port,
         final File home, final List<String> args) throws IOException {
-        return new ProcessBuilder().command(
-            new String[] {
-                new File(home, "bin/java").getAbsolutePath(),
-                new StringBuilder("-Djava.library.path=")
-                    .append(dist)
-                    .append(System.getProperty("path.separator"))
-                    .append(new File(dist, "DynamoDBLocal_lib"))
-                    .toString(),
-                "-jar",
-                "DynamoDBLocal.jar",
-                "--port",
-                Integer.toString(port),
-                StringUtils.join(args, " "),
-            }
-        ).directory(dist).redirectErrorStream(true).start();
+        ArrayList<String> command = new ArrayList<String>();
+        command.add(new File(home, "bin/java").getAbsolutePath());
+        command.add(new StringBuilder("-Djava.library.path=")
+                        .append(dist)
+                        .append(System.getProperty("path.separator"))
+                        .append(new File(dist, "DynamoDBLocal_lib"))
+                        .toString());
+        command.add("-jar");
+        command.add("DynamoDBLocal.jar");
+        command.add("--port");
+        command.add(Integer.toString(port));
+        command.addAll(args);
+
+        return new ProcessBuilder().command(command).directory(dist).redirectErrorStream(true).start();
     }
 
     /**

--- a/src/main/java/com/jcabi/dynamodb/maven/plugin/Instances.java
+++ b/src/main/java/com/jcabi/dynamodb/maven/plugin/Instances.java
@@ -35,6 +35,7 @@ import com.jcabi.log.VerboseRunnable;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
@@ -141,20 +142,25 @@ final class Instances {
      */
     private static Process process(final File dist, final int port,
         final File home, final List<String> args) throws IOException {
-        ArrayList<String> command = new ArrayList<String>();
-        command.add(new File(home, "bin/java").getAbsolutePath());
-        command.add(new StringBuilder("-Djava.library.path=")
-                        .append(dist)
-                        .append(System.getProperty("path.separator"))
-                        .append(new File(dist, "DynamoDBLocal_lib"))
-                        .toString());
-        command.add("-jar");
-        command.add("DynamoDBLocal.jar");
-        command.add("--port");
-        command.add(Integer.toString(port));
-        command.addAll(args);
-
-        return new ProcessBuilder().command(command).directory(dist).redirectErrorStream(true).start();
+        final List<String> baseCommand = Arrays.asList(
+            new File(home, "bin/java").getAbsolutePath(),
+            new StringBuilder("-Djava.library.path=")
+                .append(dist)
+                .append(System.getProperty("path.separator"))
+                .append(new File(dist, "DynamoDBLocal_lib"))
+                .toString()
+            ,
+            "-jar",
+            "DynamoDBLocal.jar",
+            "--port",
+            Integer.toString(port)
+        );
+        final List<String> commandWithArgs =
+            new ArrayList<String>(baseCommand.size() + args.size());
+        commandWithArgs.addAll(baseCommand);
+        commandWithArgs.addAll(args);
+        return new ProcessBuilder().command(commandWithArgs)
+            .directory(dist).redirectErrorStream(true).start();
     }
 
     /**

--- a/src/main/java/com/jcabi/dynamodb/maven/plugin/Instances.java
+++ b/src/main/java/com/jcabi/dynamodb/maven/plugin/Instances.java
@@ -32,9 +32,6 @@ package com.jcabi.dynamodb.maven.plugin;
 import com.jcabi.aspects.Loggable;
 import com.jcabi.log.VerboseProcess;
 import com.jcabi.log.VerboseRunnable;
-import lombok.EqualsAndHashCode;
-import lombok.ToString;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -42,8 +39,9 @@ import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-
 import javax.validation.constraints.NotNull;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /**
  * Running instances of DynamoDB Local.
@@ -143,20 +141,22 @@ final class Instances {
      */
     private static Process process(final File dist, final int port,
         final File home, final List<String> args) throws IOException {
-        final int baseCommandCount = 6;
-        final List<String> command = new ArrayList<String>(baseCommandCount + args.size());
+        final List<String> command = new ArrayList<String>(args.size());
         command.add(new File(home, "bin/java").getAbsolutePath());
-        command.add(new StringBuilder("-Djava.library.path=")
-                        .append(dist)
-                        .append(System.getProperty("path.separator"))
-                        .append(new File(dist, "DynamoDBLocal_lib"))
-                        .toString());
+        command.add(
+            new StringBuilder("-Djava.library.path=")
+                .append(dist)
+                .append(System.getProperty("path.separator"))
+                .append(new File(dist, "DynamoDBLocal_lib"))
+                .toString()
+        );
         command.add("-jar");
         command.add("DynamoDBLocal.jar");
         command.add("--port");
         command.add(Integer.toString(port));
         command.addAll(args);
-        return new ProcessBuilder().command(command).directory(dist).redirectErrorStream(true).start();
+        return new ProcessBuilder().command(command)
+            .directory(dist).redirectErrorStream(true).start();
     }
 
     /**


### PR DESCRIPTION
When multiple arguments are joined together, they are treated as a
single arugment and Dynamo fails to start.  This changes the command to
a list and appends each argument.