### PR TITLE
provide a 'run' goal for execution of dynamo db from the command line

### DIFF
--- a/src/main/java/com/jcabi/dynamodb/maven/plugin/Instances.java
+++ b/src/main/java/com/jcabi/dynamodb/maven/plugin/Instances.java
@@ -62,7 +62,7 @@ final class Instances {
      * Running processes.
      */
     private final transient ConcurrentMap<Integer, Process> processes =
-            new ConcurrentHashMap<Integer, Process>(0);
+        new ConcurrentHashMap<Integer, Process>(0);
 
     /**
      * Public ctor.

--- a/src/main/java/com/jcabi/dynamodb/maven/plugin/Instances.java
+++ b/src/main/java/com/jcabi/dynamodb/maven/plugin/Instances.java
@@ -101,6 +101,15 @@ final class Instances {
         this.processes.put(port, process);
     }
 
+    /**
+     * Launch a new one at this port. This goal will block maven.
+     * @param dist Path to DynamoDBLocal distribution
+     * @param port The port to start at
+     * @param home Java home directory
+     * @param args Command line arguments
+     * @throws IOException If fails to start
+     * @checkstyle ParameterNumber (5 lines)
+     */
     public void run(@NotNull final File dist, final int port, final File home,
                     @NotNull final List<String> args) throws IOException {
         final Process process = Instances.process(dist, port, home, args);

--- a/src/main/java/com/jcabi/dynamodb/maven/plugin/Instances.java
+++ b/src/main/java/com/jcabi/dynamodb/maven/plugin/Instances.java
@@ -62,7 +62,7 @@ final class Instances {
      * Running processes.
      */
     private final transient ConcurrentMap<Integer, Process> processes =
-        new ConcurrentHashMap<Integer, Process>(0);
+            new ConcurrentHashMap<Integer, Process>(0);
 
     /**
      * Public ctor.
@@ -99,6 +99,13 @@ final class Instances {
         thread.setDaemon(true);
         thread.start();
         this.processes.put(port, process);
+    }
+
+    public void run(@NotNull final File dist, final int port, final File home,
+                    @NotNull final List<String> args) throws IOException {
+        final Process process = Instances.process(dist, port, home, args);
+        this.processes.put(port, process);
+        new VerboseRunnable(new InstanceProcess(process)).run();
     }
 
     /**

--- a/src/main/java/com/jcabi/dynamodb/maven/plugin/RunMojo.java
+++ b/src/main/java/com/jcabi/dynamodb/maven/plugin/RunMojo.java
@@ -31,13 +31,12 @@ package com.jcabi.dynamodb.maven.plugin;
 
 import java.io.File;
 import java.io.IOException;
-
-import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.plugins.annotations.Mojo;
-import org.apache.maven.plugins.annotations.Parameter;
-
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 
 /**
  * Starts DynamoDB Local.

--- a/src/main/java/com/jcabi/dynamodb/maven/plugin/RunMojo.java
+++ b/src/main/java/com/jcabi/dynamodb/maven/plugin/RunMojo.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2012-2015, jcabi.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the jcabi.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jcabi.dynamodb.maven.plugin;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+/**
+ * Starts DynamoDB Local.
+ *
+ * @author Denis N. Antonioli (denisa@sunrun.com)
+ * @version $Id$
+ * @since 0.8
+ */
+@ToString
+@EqualsAndHashCode(callSuper = false)
+@Mojo(
+    threadSafe = true, name = "run"
+)
+public final class RunMojo extends AbstractDynamoMojo {
+
+    /**
+     * Location of DynamoDB Local distribution.
+     * @since 0.4
+     */
+    @Parameter(required = true)
+    private transient File dist;
+
+    /**
+     * Java home directory, where "bin/java" can be executed.
+     * @since 0.3
+     */
+    @Parameter(required = false)
+    private transient File home;
+
+    @Override
+    public void run(final Instances instances) throws MojoFailureException {
+        if (!this.dist.exists()) {
+            throw new MojoFailureException(
+                String.format(
+                    "DynamoDB Local distribution doesn't exist: %s",
+                    this.dist
+                )
+            );
+        }
+        if (!this.dist.isDirectory()) {
+            throw new MojoFailureException(
+                String.format(
+                    "DynamoDB Local distribution is not a directory: %s",
+                    this.dist
+                )
+            );
+        }
+        if (this.home == null) {
+            this.home = new File(System.getProperty("java.home"));
+        }
+        if (!this.home.exists()) {
+            throw new MojoFailureException(
+                String.format("Java home doesn't exist: %s", this.home)
+            );
+        }
+        try {
+            instances.run(this.dist, this.tcpPort(), this.home, this.args());
+        } catch (final IOException ex) {
+            throw new MojoFailureException(
+                "failed to start DynamoDB Local", ex
+            );
+        }
+    }
+
+}

--- a/src/main/java/com/jcabi/dynamodb/maven/plugin/RunMojo.java
+++ b/src/main/java/com/jcabi/dynamodb/maven/plugin/RunMojo.java
@@ -41,8 +41,8 @@ import org.apache.maven.plugins.annotations.Parameter;
  * Starts DynamoDB Local.
  *
  * @todo #41:30min Let's avoid code duplication between this class and `StartMojo`.
- *  One idea is to  create a decorator called `ThreadedMojo` that receives another
- *  mojo in its constructor and, when called, runs it inside a thread
+ *  One idea is to create a decorator called `ThreadedMojo` that receives
+ *  another mojo in its constructor and, when called, runs it inside a thread.
  *
  * @author Denis N. Antonioli (denisa@sunrun.com)
  * @version $Id$

--- a/src/main/java/com/jcabi/dynamodb/maven/plugin/RunMojo.java
+++ b/src/main/java/com/jcabi/dynamodb/maven/plugin/RunMojo.java
@@ -40,6 +40,10 @@ import org.apache.maven.plugins.annotations.Parameter;
 /**
  * Starts DynamoDB Local.
  *
+ * @todo #41:30min Let's avoid code duplication between this class and `StartMojo`.
+ * One idea is to  create a decorator called `ThreadedMojo` that receives another mojo in its constructor and,
+ * when called, runs it inside a thread
+ *
  * @author Denis N. Antonioli (denisa@sunrun.com)
  * @version $Id$
  * @since 0.8

--- a/src/main/java/com/jcabi/dynamodb/maven/plugin/RunMojo.java
+++ b/src/main/java/com/jcabi/dynamodb/maven/plugin/RunMojo.java
@@ -34,7 +34,6 @@ import java.io.IOException;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 

--- a/src/main/java/com/jcabi/dynamodb/maven/plugin/RunMojo.java
+++ b/src/main/java/com/jcabi/dynamodb/maven/plugin/RunMojo.java
@@ -41,8 +41,8 @@ import org.apache.maven.plugins.annotations.Parameter;
  * Starts DynamoDB Local.
  *
  * @todo #41:30min Let's avoid code duplication between this class and `StartMojo`.
- * One idea is to  create a decorator called `ThreadedMojo` that receives another mojo in its constructor and,
- * when called, runs it inside a thread
+ *  One idea is to  create a decorator called `ThreadedMojo` that receives another
+ *  mojo in its constructor and, when called, runs it inside a thread
  *
  * @author Denis N. Antonioli (denisa@sunrun.com)
  * @version $Id$

--- a/src/test/java/com/jcabi/dynamodb/maven/plugin/RunMojoTest.java
+++ b/src/test/java/com/jcabi/dynamodb/maven/plugin/RunMojoTest.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2012-2015, jcabi.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the jcabi.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jcabi.dynamodb.maven.plugin;
+
+import org.junit.Test;
+
+/**
+ * Test case for {@link RunMojo} (more detailed test is in maven invoker).
+ * @author Denis N. Antonioli (denisa@sunrun.com)
+ * @version $Id$
+ */
+public final class RunMojoTest {
+
+    /**
+     * RunMojo can skip execution when flag is set.
+     * @throws Exception If something is wrong
+     */
+    @Test
+    public void skipsExecutionWhenRequired() throws Exception {
+        final RunMojo mojo = new RunMojo();
+        mojo.setSkip(true);
+        mojo.execute();
+    }
+
+}


### PR DESCRIPTION
All the similar plugins I'm using (cargo, derby, redis) provide a _run_ goal that can be used to start the server and keep it running.

This is very handy to manually set-up a test environment, for example to debug failing tests.