### PR TITLE
keep Maven running in 'run' goal so dynamo db doesn't stop

### DIFF
--- a/src/main/java/com/jcabi/dynamodb/maven/plugin/RunMojo.java
+++ b/src/main/java/com/jcabi/dynamodb/maven/plugin/RunMojo.java
@@ -30,7 +30,9 @@
 package com.jcabi.dynamodb.maven.plugin;
 
 import com.jcabi.dynamodb.core.Instances;
+import com.jcabi.log.Logger;
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.apache.maven.plugin.MojoFailureException;
@@ -64,6 +66,18 @@ public final class RunMojo extends AbstractEnviromentMojo {
             throw new MojoFailureException(
                 "failed to run DynamoDB Local", ex
             );
+        }
+        Logger.info(
+                this, "DynamoDB is up and running on port %d",
+                this.tcpPort()
+        );
+        Logger.info(this, "Press Ctrl-C to stop...");
+        while (true) {
+            try {
+                TimeUnit.MINUTES.sleep(1L);
+            } catch (final InterruptedException ex) {
+                throw new MojoFailureException("DynamoDB terminated", ex);
+            }
         }
     }
 


### PR DESCRIPTION
I expected the `run` goal of this plugin to work like the jcabi-mysql plugin, i.e. leave Dynamo running. However, when I execute this goal, it starts and immediately stops Dynamo:

```
$ mvn jcabi-dynamodb:run
[INFO] Scanning for projects...
[INFO]                                                                         
[INFO] ------------------------------------------------------------------------
[INFO] Building offer-service-server 0.0.1-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[INFO] 
[INFO] --- jcabi-dynamodb-maven-plugin:0.7.2:run (default-cli) @ offer-service-server ---
[INFO] jcabi-aspects 0.22.2/b3b3809 started new daemon thread jcabi-loggable for watching of @Loggable annotated methods
[INFO] #start(/offer-service/offer-service-server/target/dynamodb-dist, 10101, /Library/Java/JavaVirtualMachines/jdk1.8.0_66.jdk/Contents/Home/jre, []): in 127.52ms
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 0.886 s
[INFO] Finished at: 2016-02-10T17:32:23-07:00
[INFO] Final Memory: 13M/309M
[INFO] ------------------------------------------------------------------------
[INFO] #stop(10101): in 211.36µs
```

Note the last log message: `#stop(10101): in 211.36µs`

I added a `while (true)` loop to the RunMojo, much like the one in jcabi-mysql, and now the plugin works as expected:

```
$ mvn jcabi-dynamodb:run
[INFO] Scanning for projects...
[INFO]                                                                         
[INFO] ------------------------------------------------------------------------
[INFO] Building offer-service-server 0.0.1-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[INFO] 
[INFO] --- jcabi-dynamodb-maven-plugin:1.0-SNAPSHOT:run (default-cli) @ offer-service-server ---
[INFO] jcabi-aspects 0.22.2/b3b3809 started new daemon thread jcabi-loggable for watching of @Loggable annotated methods
[INFO] #start(/offer-service/offer-service-server/target/dynamodb-dist, 10101, /Library/Java/JavaVirtualMachines/jdk1.8.0_66.jdk/Contents/Home/jre, []): in 79.40ms
[INFO] DynamoDB is up and running on port 10101
[INFO] Press Ctrl-C to stop...
[INFO] >> 2016-02-10 17:32:47.137:INFO:oejs.Server:jetty-8.1.12.v20130726
[INFO] >> 2016-02-10 17:32:47.200:INFO:oejs.AbstractConnector:Started SelectChannelConnector@0.0.0.0:10101
```

Dynamo runs until I Ctrl-C.
