### PR TITLE
Removed puzzle and edited javadoc

### DIFF
--- a/src/main/java/com/jcabi/dynamodb/core/Tables.java
+++ b/src/main/java/com/jcabi/dynamodb/core/Tables.java
@@ -120,10 +120,9 @@ public final class Tables {
 
     /**
      * Creates tables.
-     * @param instances Instances to create
      * @throws IOException if something goes wrong
      */
-    public void create(final Instances instances) throws IOException {
+    public void create() throws IOException {
         final AmazonDynamoDB aws = new AmazonDynamoDBClient(
             new BasicAWSCredentials(this.key, this.secret)
         );

--- a/src/main/java/com/jcabi/dynamodb/core/package-info.java
+++ b/src/main/java/com/jcabi/dynamodb/core/package-info.java
@@ -29,12 +29,11 @@
  */
 
 /**
- * DynamoDB core package. Logic for running local dynamodb directly.
+ * Core package. Logic of the plugin should be extracted from
+ * maven mojos to this package to allow directly running local dynamodb.
  *
  * @author Igor Piddubnyi (igor.piddubnyi@gmail.com)
  * @version $Id$
  * @since 0.8
- * @todo #38:30min Logic of the plugin should be extracted from maven mojos to
- *  this package to allow directly running local dynamodb.
  */
 package com.jcabi.dynamodb.core;

--- a/src/main/java/com/jcabi/dynamodb/maven/plugin/CreateTablesMojo.java
+++ b/src/main/java/com/jcabi/dynamodb/maven/plugin/CreateTablesMojo.java
@@ -85,7 +85,7 @@ public final class CreateTablesMojo extends AbstractDynamoMojo {
                 this.tables, this.endpoint, this.tcpPort(), this.key,
                 this.secret
             )
-                .create(instances);
+                .create();
         } catch (final IOException ex) {
             throw new MojoFailureException(
                 String.format(


### PR DESCRIPTION
This PR is for issue #52 . I do not see any more logic that can be extracted from the mojos at the moment. There are currently mojos to start/run/stop dynamodb (using ``Instances`` class) and a mojo to create tables, which uses class ``Tables``. 

Also, all the logic is tested with integration tests.

Removed unused parameter from ``Tables.create()`` . 
