### PR TITLE
Update URL for Javadoc badge's image

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![PDD status](http://www.0pdd.com/svg?name=jcabi/jcabi-dynamodb-maven-plugin)](http://www.0pdd.com/p?name=jcabi/jcabi-dynamodb-maven-plugin)
 [![Build status](https://ci.appveyor.com/api/projects/status/4ads96yp0axlg9wv?svg=true)](https://ci.appveyor.com/project/yegor256/jcabi-dynamodb-maven-plugin)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.jcabi/jcabi-dynamodb-maven-plugin/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.jcabi/jcabi-dynamodb-maven-plugin)
-[![Javadoc](https://javadoc-emblem.rhcloud.com/doc/com.jcabi/jcabi-dynamodb-maven-plugin/badge.svg)](http://www.javadoc.io/doc/com.jcabi/jcabi-dynamodb-maven-plugin)
+[![Javadoc](https://javadoc.io/badge/com.jcabi/jcabi-dynamodb-maven-plugin.svg)](http://www.javadoc.io/doc/com.jcabi/jcabi-dynamodb-maven-plugin)
 
 More details are here: [dynamodb.jcabi.com](http://dynamodb.jcabi.com/index.html).
 Also, read this blog post: [DynamoDB Local Maven Plugin](http://www.yegor256.com/2014/05/01/dynamodb-local-maven-plugin.html).


### PR DESCRIPTION
OpenShit Online V2 is closed and this domain is not accessible anymore.
And javadoc.io introduce badges hosted directly on javadoc.io