### PR TITLE
Fixed JSON deserialization of non-key attributes for secondary indices

### DIFF
--- a/src/main/java/com/jcabi/dynamodb/core/Tables.java
+++ b/src/main/java/com/jcabi/dynamodb/core/Tables.java
@@ -49,10 +49,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collection;
 import java.util.LinkedList;
-import javax.json.Json;
-import javax.json.JsonArray;
-import javax.json.JsonObject;
-import javax.json.JsonValue;
+import javax.json.*;
 
 /**
  * Handles DynamoDB locations.
@@ -287,7 +284,8 @@ public final class Tables {
         if (projn.containsKey("NonKeyAttributes")) {
             for (final JsonValue nonkey
                 : projn.getJsonArray("NonKeyAttributes")) {
-                nonkeyattrs.add(nonkey.toString());
+                final JsonString nonKeyAttributeName = (JsonString) nonkey;
+                nonkeyattrs.add(nonKeyAttributeName.getString());
             }
             projection.setNonKeyAttributes(nonkeyattrs);
         }

--- a/src/main/java/com/jcabi/dynamodb/core/Tables.java
+++ b/src/main/java/com/jcabi/dynamodb/core/Tables.java
@@ -49,7 +49,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collection;
 import java.util.LinkedList;
-import javax.json.*;
+import javax.json.Json;
+import javax.json.JsonArray;
+import javax.json.JsonObject;
+import javax.json.JsonString;
+import javax.json.JsonValue;
 
 /**
  * Handles DynamoDB locations.

--- a/src/main/java/com/jcabi/dynamodb/core/Tables.java
+++ b/src/main/java/com/jcabi/dynamodb/core/Tables.java
@@ -288,8 +288,8 @@ public final class Tables {
         if (projn.containsKey("NonKeyAttributes")) {
             for (final JsonValue nonkey
                 : projn.getJsonArray("NonKeyAttributes")) {
-                final JsonString nonKeyAttributeName = (JsonString) nonkey;
-                nonkeyattrs.add(nonKeyAttributeName.getString());
+                final JsonString nonKeyName = (JsonString) nonkey;
+                nonkeyattrs.add(nonKeyName.getString());
             }
             projection.setNonKeyAttributes(nonkeyattrs);
         }


### PR DESCRIPTION
Previously, the JSON string representation was being used, resulting with attribute names surrounded with double quotes.  This fixes it so that the JSON string value is used instead.

Many thanks for your contribution, we truly appreciate it. We will appreciate it even more, if you make sure that you can say "YES" to each point in this short checklist:

  - You made a small amount of changes (less than 100 lines, less than 10 files) = YES
  - You made changes related to only one bug (create separate PRs for separate problems) = YES
  - You are ready to defend your changes (there will be a code review) = YES
  - You don't touch what you don't understand = YES
  - You ran the build locally and it passed = YES

This article will help you understand what we are looking for: http://www.yegor256.com/2015/02/09/serious-code-reviewer.html

Thank you for your contribution!
